### PR TITLE
Add update-formula Github action

### DIFF
--- a/.github/workflows/update-formula.yaml
+++ b/.github/workflows/update-formula.yaml
@@ -1,0 +1,88 @@
+name: Update formula
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Juvix version (e.g. 0.4.0)'
+        required: true
+      revision:
+        description: 'Juvix release git ref (e.g 925d7cb749711168d9baf6fc176a06330398824e)'
+
+jobs:
+  validate-input:
+    name: "Validate version string"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version
+        run: |
+          JUVIX_VERSION="${{ github.event.inputs.version }}"
+          echo "::debug::version $JUVIX_VERSION"
+          if [[ ! $JUVIX_VERSION =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
+            echo
+            echo "::error::Bad version input"
+            exit 1
+          fi
+      - name: Validate revision
+        run: |
+          JUVIX_REVISION="${{ github.event.inputs.revision }}"
+          echo "::debug::revision $JUVIX_REVISION"
+          if [[ ! $JUVIX_REVISION =~ ^[a-f0-9]{40}$ ]]; then
+            echo
+            echo "::error::Bad revision input"
+            exit 1
+          fi
+
+  update-formula:
+    name: "Make a PR that updates the juvix formula"
+    needs: validate-input
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+    steps:
+      - name: Setup parameters
+        run: |
+          JUVIX_VERSION="${{ github.event.inputs.version }}"
+          JUVIX_REVISION="${{ github.event.inputs.revision }}"
+
+          echo "::debug::version $JUVIX_VERSION"
+          echo "::debug::revision $JUVIX_REVISION"
+
+          echo "JUVIX_VERSION=$JUVIX_VERSION" >> $GITHUB_ENV
+          echo "JUVIX_REVISION=$JUVIX_REVISION" >> $GITHUB_ENV
+
+      - name: Tap formula
+        run: |
+          brew tap anoma/juvix
+          echo "BREW_TAP_DIRECTORY=$(brew --repository anoma/juvix)" >> $GITHUB_ENV
+
+      - name: Create branch
+        working-directory: ${{ env.BREW_TAP_DIRECTORY }}
+        run: |
+          BRANCH_NAME="juvix-formula-update-${JUVIX_VERSION}-${RANDOM}"
+          git checkout -b $BRANCH_NAME
+          git push -u origin $BRANCH_NAME
+
+      - name: Update homebrew formula
+        working-directory: ${{ env.BREW_TAP_DIRECTORY }}
+        run: |
+          brew bump-formula-pr \
+          --version $JUVIX_VERSION \
+          --revision $JUVIX_REVISION \
+          --no-audit \
+          --write-only \
+          --commit \
+          --verbose \
+          Formula/juvix.rb
+
+      - name: Push commit
+        working-directory: ${{ env.BREW_TAP_DIRECTORY }}
+        run: |
+          git push
+
+      - name: Open pull request
+        working-directory: ${{ env.BREW_TAP_DIRECTORY }}
+        run: |
+          git pr create \
+          --title "juvix $JUVIX_VERSION" \
+          --body "Created by update-formula action"

--- a/.github/workflows/update-formula.yaml
+++ b/.github/workflows/update-formula.yaml
@@ -7,6 +7,7 @@ on:
         required: true
       revision:
         description: 'Juvix release git ref (e.g 925d7cb749711168d9baf6fc176a06330398824e)'
+        required: true
 
 jobs:
   validate-input:

--- a/.github/workflows/update-formula.yaml
+++ b/.github/workflows/update-formula.yaml
@@ -40,6 +40,7 @@ jobs:
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_INSTALL_FROM_API: 1
     steps:
       - name: Setup parameters
         run: |
@@ -75,6 +76,19 @@ jobs:
           --commit \
           --verbose \
           Formula/juvix.rb
+
+      - name: Build x86_64 bottle
+        working-directory: ${{ env.BREW_TAP_DIRECTORY }}
+        run: |
+          brew install --build-bottle --verbose --debug Formula/juvix.rb
+          brew bottle --write --root-url https://github.com/anoma/juvix/releases/download/v$JUVIX_VERSION Formula/juvix.rb
+
+      - name: Upload x86_64 bottle
+        working-directory: ${{ env.BREW_TAP_DIRECTORY }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: juvix-x86-bottle
+          path: juvix*.tar.gz
 
       - name: Push commit
         working-directory: ${{ env.BREW_TAP_DIRECTORY }}

--- a/Formula/juvix.rb
+++ b/Formula/juvix.rb
@@ -1,156 +1,156 @@
 # coding: utf-8
 class Juvix < Formula
-    desc "The Juvix compiler"
-    homepage "https://juvix.org"
+  desc "Compiler"
+  homepage "https://juvix.org"
+  license "AGPL-3.0-or-later"
+
+  # This version must match the GHC version used by the stack resolver in the Juvix project
+  @@ghc_version = "9.2.7"
+
+  stable do
+    url "https://github.com/anoma/juvix.git",
+        using:    :git,
+        revision: "925d7cb749711168d9baf6fc176a06330398824e"
+    version "0.4.0"
+  end
+
+  livecheck do
+    skip "No version information available to check"
+  end
+
+  bottle do
+    root_url "https://github.com/anoma/juvix/releases/download/v0.4.0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "aeb02413753fdb3a5c427025e44f2eb1ac38510ff7911e99533c42f4a11cc7c4"
+    sha256 cellar: :any_skip_relocation, ventura:       "c0efd50f71d8fcbe7cc410af3fa707dcc4afd19edfa8fcdfd29fa36e6d1a27b6"
+  end
+
+  head do
     url "https://github.com/anoma/juvix.git", branch: "main"
-    license "AGPL-3.0-or-later"
+  end
 
-    # This version must match the GHC version used by the stack resolver in the Juvix project
-    @@ghc_version = "9.2.7"
-    
-    stable do
-      url "https://github.com/anoma/juvix.git", branch: "main"
-      version "0.4.0"
-      sha256 "925d7cb749711168d9baf6fc176a06330398824e"
-    end
-    
-    head do
-      url "https://github.com/anoma/juvix.git", branch: "main"
-    end
+  option "without-stack", "Do not install Haskell-Stack"
 
-    livecheck do
-      skip "No version information available to check"
-    end
-  
-    option "without-stack", "Do not install Haskell-Stack"
-    
-    depends_on "make" => :build
-    depends_on "llvm" => :build
-    depends_on "stack" => :build
-  
-    bottle do
-        root_url "https://github.com/anoma/juvix/releases/download/v0.4.0"
-        sha256 cellar: :any_skip_relocation, arm64_ventura: "aeb02413753fdb3a5c427025e44f2eb1ac38510ff7911e99533c42f4a11cc7c4"
-        sha256 cellar: :any_skip_relocation, ventura: "c0efd50f71d8fcbe7cc410af3fa707dcc4afd19edfa8fcdfd29fa36e6d1a27b6"
-    end
+  depends_on "llvm" => :build
+  depends_on "make" => :build
+  depends_on "stack" => :build
 
-    def get_system_architecture
-      require 'rbconfig'
-      RbConfig::CONFIG['host_cpu']
-    end
+  def system_architecture
+    require "rbconfig"
+    RbConfig::CONFIG["host_cpu"]
+  end
 
-    def install
-      require "tmpdir"
-      jobs = ENV.make_jobs
-      opts = [ "--stack-root", buildpath/".stack" ]
-      # The runtime build must use the homebrew LLVM installation, not the one provided by macOS.
-      system "make", "runtime", "CC=#{Formula["llvm"].opt_bin}/clang", "LIBTOOL=#{Formula["llvm"].opt_bin}/llvm-ar"
-      arch = get_system_architecture
-      ghc_basename = "ghc-#{@@ghc_version}-#{arch}-apple-darwin"
-      ghc_archive_name = "#{ghc_basename}.tar.xz"
+  def install
+    require "tmpdir"
+    jobs = ENV.make_jobs
+    opts = ["--stack-root", buildpath/".stack"]
+    # The runtime build must use the homebrew LLVM installation, not the one provided by macOS.
+    system "make", "runtime", "CC=#{Formula["llvm"].opt_bin}/clang", "LIBTOOL=#{Formula["llvm"].opt_bin}/llvm-ar"
+    arch = system_architecture
+    ghc_basename = "ghc-#{@@ghc_version}-#{arch}-apple-darwin"
+    ghc_archive_name = "#{ghc_basename}.tar.xz"
 
-      ghc_root = Dir.mktmpdir
-      begin
-        ENV.prepend_path "PATH", "#{ghc_root}/bin"
-        with_env(
-          "LD" => "ld",
-        ) do
-          # We install GHC using the binary release directly because installation of GHC via ghcup
-          # or via stack in the formula context is not reliable.
-          system "curl", "-OL", "https://downloads.haskell.org/~ghc/#{@@ghc_version}/#{ghc_archive_name}"
-          system "tar", "xf", "#{ghc_archive_name}"
-          Dir.chdir("#{ghc_basename}") do
-            system "./configure", "--prefix=#{ghc_root}"
-            system "make", "install"
-          end
-          system "stack", "--system-ghc", "--no-install-ghc", "-j#{jobs}", "--local-bin-path=#{bin}", "install", *opts
+    ghc_root = Dir.mktmpdir
+    begin
+      ENV.prepend_path "PATH", "#{ghc_root}/bin"
+      with_env(
+        "LD" => "ld",
+      ) do
+        # We install GHC using the binary release directly because installation of GHC via ghcup
+        # or via stack in the formula context is not reliable.
+        system "curl", "-OL", "https://downloads.haskell.org/~ghc/#{@@ghc_version}/#{ghc_archive_name}"
+        system "tar", "xf", ghc_archive_name.to_s
+        Dir.chdir(ghc_basename.to_s) do
+          system "./configure", "--prefix=#{ghc_root}"
+          system "make", "install"
         end
-        share.install Dir["juvix-mode/*"]
-        share.install Dir["examples/*"]
-      ensure
-        FileUtils.remove_entry(ghc_root) if ghc_root
+        system "stack", "--system-ghc", "--no-install-ghc", "-j#{jobs}", "--local-bin-path=#{bin}", "install", *opts
       end
+      share.install Dir["juvix-mode/*"]
+      share.install Dir["examples/*"]
+    ensure
+      remove_entry(ghc_root) if ghc_root
     end
+  end
 
-    def caveats
-      <<~EOS
-        =============================== Juvix examples =================================
-        To see all the Juvix example files, check out the path:
+  def caveats
+    <<~EOS
+      =============================== Juvix examples =================================
+      To see all the Juvix example files, check out the path:
 
-          #{share}/milestone
+        #{share}/milestone
 
-        There, you might want to typecheck a Juvix file. For example, run:
-        
-          juvix typecheck Fibonacci/Fibonacci.juvix
+      There, you might want to typecheck a Juvix file. For example, run:
 
-        ============================ Juvix mode for Emacs ==============================
-        To install the Juvix mode in Emacs, please add the following lines to the
-        configuration file (often at "~/.emacs.d").
-          
-          (push "#{share}" load-path)
-              (require 'juvix-mode)
-            
-        Restart Emacs for the change to take effect. Open Emacs again and the Juvix mode
-        will be activated automatically for files with extension ".juvix".
-        
-        To typecheck a Juvix file using the keybinding, press "Ctrl-c + Ctrl-l".
-        
-        In case you're missing Emacs, we recommend you to install it as follows on MacOS:
+        juvix typecheck Fibonacci/Fibonacci.juvix
 
-          brew tap d12frosted/emacs-plus
-          brew install emacs-plus@28
+      ============================ Juvix mode for Emacs ==============================
+      To install the Juvix mode in Emacs, please add the following lines to the
+      configuration file (often at "~/.emacs.d").
+      #{"  "}
+        (push "#{share}" load-path)
+            (require 'juvix-mode)
+      #{"    "}
+      Restart Emacs for the change to take effect. Open Emacs again and the Juvix mode
+      will be activated automatically for files with extension ".juvix".
 
-        ============================= Juvix VSCode =====================================
+      To typecheck a Juvix file using the keybinding, press "Ctrl-c + Ctrl-l".
 
-        You can find the Juvix-Mode plugin in the VSCode marketplace. Alternatively, you
-        can run the following command on your shell:
+      In case you're missing Emacs, we recommend you to install it as follows on MacOS:
 
-          ext install heliax.juvix-mode
-        
-        ====================== Install the auto-completion Scripts =====================
-        To get the Juvix CLI completions for your shell, run the following:
+        brew tap d12frosted/emacs-plus
+        brew install emacs-plus@28
 
-        * Bash
-          juvix --bash-completion-script juvix > ~/.bashrc
-        
-        * FISH
-          juvix --fish-completion-script juvix > ~/.config/fish/completions/juvix.fish
-        
-        * ZSH 
-          juvix --zsh-completion-script juvix > $DIR_IN_FPATH/_juvix
-        
-        The variable $DIR_IN_FPATH is a directory that is present on the ZSH FPATH
-        variable (which you can inspect by running `echo $FPATH` in the shell).
-        
-        Restart your terminal for the settings to take effect.
-        
-        ======================== Compile Juvix programs to Wasm ========================  
-        To compile Juvix to Wasm, please follow the instructions on the website.
-        The requirement are: wasmer, Clang/LLVM, wasi-sdk, and wasm-ld.
-        
-        https://docs.juvix.org/latest/howto/installing/
-        
-        ============================ Getting more help =================================
-        To see all the Juvix commands, run:
-          juvix --help
+      ============================= Juvix VSCode =====================================
 
-        To check your setup, run:
-          juvix doctor
+      You can find the Juvix-Mode plugin in the VSCode marketplace. Alternatively, you
+      can run the following command on your shell:
 
-        For more documentation, please check out the Juvix Book website:
-          https://docs.juvix.org
+        ext install heliax.juvix-mode
 
-        or the Github repository:
-          https://github.com/anoma/juvix
+      ====================== Install the auto-completion Scripts =====================
+      To get the Juvix CLI completions for your shell, run the following:
 
-        To see these instructions, run:
-          brew info juvix
-      EOS
-    end
+      * Bash
+        juvix --bash-completion-script juvix > ~/.bashrc
 
-    test do
-      stdlibtest = testpath/"Fibonacci.juvix"
-      stdlibtest.write <<~EOS
+      * FISH
+        juvix --fish-completion-script juvix > ~/.config/fish/completions/juvix.fish
+
+      * ZSH#{" "}
+        juvix --zsh-completion-script juvix > $DIR_IN_FPATH/_juvix
+
+      The variable $DIR_IN_FPATH is a directory that is present on the ZSH FPATH
+      variable (which you can inspect by running `echo $FPATH` in the shell).
+
+      Restart your terminal for the settings to take effect.
+
+      ======================== Compile Juvix programs to Wasm ========================#{"  "}
+      To compile Juvix to Wasm, please follow the instructions on the website.
+      The requirement are: wasmer, Clang/LLVM, wasi-sdk, and wasm-ld.
+
+      https://docs.juvix.org/latest/howto/installing/
+
+      ============================ Getting more help =================================
+      To see all the Juvix commands, run:
+        juvix --help
+
+      To check your setup, run:
+        juvix doctor
+
+      For more documentation, please check out the Juvix Book website:
+        https://docs.juvix.org
+
+      or the Github repository:
+        https://github.com/anoma/juvix
+
+      To see these instructions, run:
+        brew info juvix
+    EOS
+  end
+
+  test do
+    stdlibtest = testpath/"Fibonacci.juvix"
+    stdlibtest.write <<~EOS
       module Fibonacci;
 
       open import Stdlib.Prelude;
@@ -165,11 +165,10 @@ class Juvix < Formula
       main : IO;
       main := readLn (printNatLn ∘ fibonacci ∘ stringToNat);
 
-      EOS
-  
-      assert_equal "Well done! It type checks\n", shell_output("#{bin}/juvix typecheck #{stdlibtest}")
-      # system bin/"juvix", "compile", stdlibtest
-      # assert_equal "75025" , shell_output("wasmer  #{testpath}/Fibonacci.wasm")
-    end
+    EOS
 
+    assert_equal "Well done! It type checks\n", shell_output("#{bin}/juvix typecheck #{stdlibtest}")
+    # system bin/"juvix", "compile", stdlibtest
+    # assert_equal "75025" , shell_output("wasmer  #{testpath}/Fibonacci.wasm")
   end
+end


### PR DESCRIPTION
> ⚠️ This PR depends on https://github.com/anoma/homebrew-juvix/pull/11

This PR adds a Github action to automatically update the Juvix homebrew formula.

This action can only be triggered manually.

When triggered, the new Juvix version and release revision must be specified. The action then uses `brew bump-formula-pr` to edit the formula and it creates a new PR with the changes.